### PR TITLE
Strings: Fix typo in notification from 'Kernek' to 'Kernel'

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -812,7 +812,7 @@
     <string name="no_plugins">No plugins found</string>
     <string name="installed">Installed</string>
     <string name="update_available">Update available</string>
-    <string name="update_available_open_app">Open Kernek Adiutor-Mod to download</string>
+    <string name="update_available_open_app">Open Kernel Adiutor-Mod to download</string>
     <string name="not_installed">Not installed</string>
 
     <!-- Downloads -->


### PR DESCRIPTION
Fix this typo.
