### PR TITLE
Add Support for fast_charge_current

### DIFF
--- a/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/BatteryFragment.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/fragments/kernel/BatteryFragment.java
@@ -53,6 +53,7 @@ public class BatteryFragment extends RecyclerViewFragment implements SwitchCardV
     private SeekBarCardView.DSeekBarCard mBlxCard, mACLevelCard, mUSBLevelCard;
 
     private SwitchCardView.DSwitchCard mCustomChargeRateEnableCard;
+    private SeekBarCardView.DSeekBarCard mForceFastChargeCurrentCard;
     private SeekBarCardView.DSeekBarCard mChargingRateCard;
     private SeekBarCardView.DSeekBarCard mlowpowervalueCard;
 
@@ -134,8 +135,20 @@ public class BatteryFragment extends RecyclerViewFragment implements SwitchCardV
         mForceFastChargeCard.setDescription(getString(R.string.usb_fast_charge_summary));
         mForceFastChargeCard.setChecked(Battery.isForceFastChargeActive());
         mForceFastChargeCard.setOnDSwitchCardListener(this);
-
         addView(mForceFastChargeCard);
+
+        if(Battery.hasForceFastChargeCurrent()){
+            List<String> list = new ArrayList<>();
+            for (int i = 0; i < 2200; i+=10) list.add(String.valueOf(i));
+
+            mForceFastChargeCurrentCard = new SeekBarCardView.DSeekBarCard(list);
+            mForceFastChargeCurrentCard.setTitle(getString(R.string.usb_fast_charge_current));
+            mForceFastChargeCurrentCard.setDescription(getString(R.string.usb_fast_charge_current_summary));
+            mForceFastChargeCurrentCard.setProgress(Battery.getFastChargeCurrent() / 10);
+            mForceFastChargeCurrentCard.setOnDSeekBarCardListener(this);
+            addView(mForceFastChargeCurrentCard);
+        }
+
     }
 
     private void chargeLevelControlInit(){
@@ -379,6 +392,8 @@ public class BatteryFragment extends RecyclerViewFragment implements SwitchCardV
             Battery.setBlx(position, getActivity());
         else if (dSeekBarCard == mACLevelCard)
             Battery.setChargeLevelControlAC(position * 10, getActivity());
+        else if (dSeekBarCard == mForceFastChargeCurrentCard)
+            Battery.setFastChargeCurrent(position * 10, getActivity());
         else if (dSeekBarCard == mUSBLevelCard)
             Battery.setChargeLevelControlUSB(position * 10, getActivity());
         else if (dSeekBarCard == mChargingRateCard)

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/Constants.java
@@ -756,6 +756,7 @@ public interface Constants {
 
     // Battery
     String FORCE_FAST_CHARGE = "/sys/kernel/fast_charge/force_fast_charge";
+    String FORCE_FAST_CHARGE_CURRENT = "/sys/kernel/fast_charge_current/force_fast_charge_current";
     String BLX = "/sys/devices/virtual/misc/batterylifeextender/charging_limit";
     String CHARGE_LEVEL = "/sys/kernel/charge_levels";
     String AC_CHARGE_LEVEL = CHARGE_LEVEL + "/charge_level_ac";

--- a/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Battery.java
+++ b/app/src/main/java/com/grarak/kerneladiutor/utils/kernel/Battery.java
@@ -83,12 +83,24 @@ public class Battery implements Constants {
         Control.runCommand(active ? "1" : "0", FORCE_FAST_CHARGE, Control.CommandType.GENERIC, context);
     }
 
+    public static void setFastChargeCurrent(int value, Context context) {
+        Control.runCommand(String.valueOf(value), FORCE_FAST_CHARGE_CURRENT, Control.CommandType.GENERIC, context);
+    }
+
+    public static int getFastChargeCurrent() {
+        return Utils.stringToInt(Utils.readFile(FORCE_FAST_CHARGE_CURRENT));
+    }
+
     public static boolean isForceFastChargeActive() {
         return Utils.readFile(FORCE_FAST_CHARGE).equals("1");
     }
 
     public static boolean hasForceFastCharge() {
         return Utils.existFile(FORCE_FAST_CHARGE);
+    }
+
+    public static boolean hasForceFastChargeCurrent() {
+        return Utils.existFile(FORCE_FAST_CHARGE_CURRENT);
     }
 
     public static boolean hasChargeLevelControl() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -642,6 +642,8 @@
     <string name="battery_temperature">Battery Temperature</string>
     <string name="usb_fast_charge">USB Fast Charge</string>
     <string name="usb_fast_charge_summary">Device will charge faster when connected with USB. Replug your charger when changing this option.</string>
+    <string name="usb_fast_charge_current">USB Fast Charge Current</string>
+    <string name="usb_fast_charge_current_summary">Device will charge with this current when connected with USB.</string>
     <string name="charge_levels">Charge Levels Interface</string>
     <string name="charge_levels_summary">Setting levels higher than your device supports can damage your device and any device it is plugged into. USE CAUTION.</string>
     <string name="charge_level_ac">AC Charge Level</string>


### PR DESCRIPTION
sysfs node: /sys/kernel/fast_charge_current/force_fast_charge_current
sample kernel implementation: https://github.com/NachiketNamjoshi/BlackReactor_onyx/commit/2752ca82139895546d2d027cda3769501deb8bab

fast_charge_current is a add-on for fast_charge to control current value.
Screenshot below is taken from device: OnePlus X, Running Android N based ROM
and has been tested on Moto G4, YU Yureka, Moto E and Moto G1. (Android 5.x,6.x, and 7.x in no respective order) and is working on every one of them.

![screenshot](https://cloud.githubusercontent.com/assets/4344226/19716877/9fd2edf0-9b7b-11e6-968d-31d17d858d72.png)

Signed-off-by: NachiketNamjoshi nachiketnamjoshi@gmail.com
